### PR TITLE
Map flat package object to an array for backwards compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,8 +86,29 @@ function installPackages (pkgs, cb) {
     if (err) {
       return cb(err)
     }
-    cb(null, JSON.parse(stdout))
+    cb(null, packagesToArray(JSON.parse(stdout)))
   })
+}
+
+function mapPackages(deps, key){
+  return {
+    name: key,
+    version: deps[key].version
+  }
+}
+
+function packagesToArray (packages) {
+  if (Array.isArray(packages)) {
+    return packages
+  }
+
+  if (packages.dependencies) {
+    return Object
+      .keys(packages.dependencies)
+      .map(mapPackages.bind(null, packages.dependencies))
+  }
+
+  return [];
 }
 
 function getBytes (cb) {


### PR DESCRIPTION
npm3 packages are an object with a dependencies property but weigh expects an array. If packages are an object, convert to the expected array, otherwise return an empty array which results in no log.
