### PR TITLE
strip out non-JSON lines from npm stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,10 @@ function installPackages (pkgs, cb) {
     if (err) {
       return cb(err)
     }
+    // Sometimes, npm gives lines that aren't JSON, so strip those out.
+    stdout = stdout.split('\n').filter(function (line) {
+      return line.substring(0, 2) !== '> ';
+    }).join('\n');
     cb(null, packagesToArray(JSON.parse(stdout)))
   })
 }


### PR DESCRIPTION
Love this tool! But sometimes, npm stdout looks like this:

``` plain
> history@1.13.1 postinstall /usr/local/lib/node_modules/weigh/.cached_modules/node_modules/history
> node ./npm-scripts/postinstall.js

[
  {
    "name": "history",
    "version": "1.13.1",
    "from": "history@latest",
    "dependencies": {
      "deep-equal": {
        "version": "1.0.1",
        "from": "deep-equal@>=1.0.0 <2.0.0",
        "dependencies": {}
      },
      "qs": {
        "version": "4.0.0",
        "from": "qs@>=4.0.0 <5.0.0",
        "dependencies": {}
      },
      "warning": {
        "version": "2.1.0",
        "from": "warning@>=2.0.0 <3.0.0",
        "dependencies": {
          "loose-envify": {
            "version": "1.1.0",
            "from": "loose-envify@>=1.0.0 <2.0.0",
            "dependencies": {
              "js-tokens": {
                "version": "1.0.2",
                "from": "js-tokens@>=1.0.1 <2.0.0",
                "dependencies": {}
              }
            }
          }
        }
      },
      "invariant": {
        "version": "2.2.0",
        "from": "invariant@>=2.0.0 <3.0.0",
        "dependencies": {
          "loose-envify": {
            "version": "1.1.0",
            "from": "loose-envify@>=1.0.0 <2.0.0",
            "dependencies": {
              "js-tokens": {
                "version": "1.0.2",
                "from": "js-tokens@>=1.0.1 <2.0.0",
                "dependencies": {}
              }
            }
          }
        }
      }
    }
  }
]
```

And in that case, weigh chokes when it tries to parse stdout. This PR just strips out lines that start with `>`, which fixes the problem.
