### PR TITLE
Respect `browser` field

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,7 +10,7 @@ var zlib = require('zlib')
 var humanize = require('humanize-list')
 var envify = require('envify')
 var fs = require('fs')
-var resolveFrom = require('resolve-from')
+var browserResolve = require('browser-resolve')
 var through = require('through')
 var parseArgs = require('minimist')
 var xtend = require('xtend')
@@ -262,7 +262,7 @@ installPackages(packages, function (err, installedPackages) {
 
   var regular = packages.filter(isPackage).map(formatPackage())
     .map(function (pkg) {
-      return resolveFrom(MODULE_CACHE_PATH, pkg)
+      return browserResolve.sync(pkg, {filename: path.join(MODULE_CACHE_PATH, 'index.js')})
     })
 
   var local = regular.filter(isLocal).map(function (pkg) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Bjørge Næss",
   "license": "MIT",
   "dependencies": {
+    "browser-resolve": "^1.11.1",
     "browserify": "^13.0.0",
     "dev-null": "^0.1.1",
     "envify": "^3.4.0",
@@ -27,7 +28,6 @@
     "ora": "^0.2.0",
     "pretty-bytes": "^3.0.1",
     "require-package-name": "^2.0.1",
-    "resolve-from": "^2.0.0",
     "rimraf": "^2.5.2",
     "tempfile": "^1.1.1",
     "through": "^2.3.8",


### PR DESCRIPTION
Currently `weigh` does not respect the `browser` field, which gives some pretty terrible results in cases like `isomorphic-fetch`. This PR replaces the use of `resolve-from` with `browser-resolve`, which fixes this.
